### PR TITLE
[REFACTOR] 세션 시작 시 409 에러 발생하면 현재 진행 중인 세션 ID 반환

### DIFF
--- a/src/main/java/com/example/peakly/domain/focusSession/dto/response/FocusSessionConflictPayload.java
+++ b/src/main/java/com/example/peakly/domain/focusSession/dto/response/FocusSessionConflictPayload.java
@@ -1,0 +1,3 @@
+package com.example.peakly.domain.focusSession.dto.response;
+
+public record FocusSessionConflictPayload(Long activeSessionId) {}

--- a/src/main/java/com/example/peakly/domain/focusSession/repository/FocusSessionRepository.java
+++ b/src/main/java/com/example/peakly/domain/focusSession/repository/FocusSessionRepository.java
@@ -2,9 +2,13 @@ package com.example.peakly.domain.focusSession.repository;
 
 import com.example.peakly.domain.focusSession.entity.FocusSession;
 import com.example.peakly.domain.focusSession.entity.SessionStatus;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -13,4 +17,18 @@ public interface FocusSessionRepository extends JpaRepository<FocusSession, Long
     Optional<FocusSession> findByIdAndUser_Id(Long sessionId, Long userId);
 
     boolean existsByUser_IdAndSessionStatusIn(Long userId, Iterable<SessionStatus> statuses);
+
+    @Query("""
+        select fs
+        from FocusSession fs
+        where fs.user.id = :userId
+          and fs.sessionStatus in :statuses
+        order by fs.startedAt desc
+    """)
+    List<FocusSession> findActiveSessions(
+            @Param("userId") Long userId,
+            @Param("statuses") List<SessionStatus> statuses,
+            Pageable pageable
+    );
+
 }

--- a/src/main/java/com/example/peakly/domain/focusSession/service/FocusSessionServiceImpl.java
+++ b/src/main/java/com/example/peakly/domain/focusSession/service/FocusSessionServiceImpl.java
@@ -7,10 +7,7 @@ import com.example.peakly.domain.category.repository.MajorCategoryRepository;
 import com.example.peakly.domain.focusSession.command.FocusSessionStartCommand;
 import com.example.peakly.domain.focusSession.dto.request.FocusSessionEndRequest;
 import com.example.peakly.domain.focusSession.dto.request.FocusSessionStartRequest;
-import com.example.peakly.domain.focusSession.dto.response.FocusSessionEndResponse;
-import com.example.peakly.domain.focusSession.dto.response.FocusSessionPauseResponse;
-import com.example.peakly.domain.focusSession.dto.response.FocusSessionResumeResponse;
-import com.example.peakly.domain.focusSession.dto.response.FocusSessionStartResponse;
+import com.example.peakly.domain.focusSession.dto.response.*;
 import com.example.peakly.domain.focusSession.entity.FocusSession;
 import com.example.peakly.domain.focusSession.entity.SessionPause;
 import com.example.peakly.domain.focusSession.entity.SessionStatus;
@@ -24,6 +21,7 @@ import com.example.peakly.global.apiPayload.code.status.UserErrorStatus;
 import com.example.peakly.global.apiPayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,12 +50,20 @@ public class FocusSessionServiceImpl implements FocusSessionService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(UserErrorStatus.USER_NOT_FOUND));
 
-        boolean exists = focusSessionRepository.existsByUser_IdAndSessionStatusIn(
+        var activeStatuses = List.of(SessionStatus.RUNNING, SessionStatus.PAUSED);
+
+        List<FocusSession> activeSessions = focusSessionRepository.findActiveSessions(
                 userId,
-                List.of(SessionStatus.RUNNING, SessionStatus.PAUSED)
+                activeStatuses,
+                PageRequest.of(0, 1)
         );
-        if (exists) {
-            throw new GeneralException(FocusSessionErrorStatus.SESSION_ALREADY_RUNNING);
+
+        if (!activeSessions.isEmpty()) {
+            FocusSession active = activeSessions.get(0);
+            throw new GeneralException(
+                    FocusSessionErrorStatus.SESSION_ALREADY_RUNNING,
+                    new FocusSessionConflictPayload(active.getId())
+            );
         }
 
         MajorCategory major = majorCategoryRepository.findById(req.majorCategoryId())

--- a/src/main/java/com/example/peakly/global/apiPayload/exception/GeneralException.java
+++ b/src/main/java/com/example/peakly/global/apiPayload/exception/GeneralException.java
@@ -5,8 +5,19 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class GeneralException extends RuntimeException {
 
     private final BaseErrorCode code;
+    private final Object payload;
+
+    public GeneralException(BaseErrorCode code) {
+        this(code, null);
+    }
+
+    public GeneralException(BaseErrorCode code, Object payload) {
+        super(code.getReasonHttpStatus().getMessage()); // optional(로그/디버그에 도움)
+        this.code = code;
+        this.payload = payload;
+    }
+
 }

--- a/src/main/java/com/example/peakly/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/example/peakly/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -35,7 +35,7 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
             GeneralException exception,
             HttpServletRequest request
     ) {
-        return handleExceptionInternal(exception, exception.getCode(), null, request);
+        return handleExceptionInternal(exception, exception.getCode(), exception.getPayload(), request);
     }
 
     /**
@@ -140,20 +140,15 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
      * === 내부 공통 처리 ===
      */
     private ResponseEntity<Object> handleExceptionInternal(
-            Exception e,
+            Exception ex,
             BaseErrorCode code,
-            HttpHeaders headers,
+            Object result,
             HttpServletRequest request
     ) {
-        ApiResponse<Object> body = ApiResponse.onFailure(code, null);
-        WebRequest webRequest = new ServletWebRequest(request);
-        return super.handleExceptionInternal(
-                e,
-                body,
-                headers,
-                code.getReasonHttpStatus().getHttpStatus(),
-                webRequest
-        );
+        ApiResponse<Object> body = ApiResponse.onFailure(code, result);
+        return ResponseEntity
+                .status(code.getReasonHttpStatus().getHttpStatus())
+                .body(body);
     }
 
     private ResponseEntity<Object> handleExceptionInternalFalse(


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
Closes #31

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
세션 시작 시 이미 진행 중인 세션이 존재하여 409 에러가 발생하면 현재 진행 중인 세션 ID를 반환하도록 했습니다.

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
X

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
핸들러 일부 수정

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|  409 에러 확인  | <img width="1395" height="888" alt="image" src="https://github.com/user-attachments/assets/086fcd08-736f-4873-9f77-c003499206a6" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 포커스 세션 충돌 감지 개선: 새 세션 시작 시 활성 세션이 있으면 더 자세한 오류 정보를 제공하도록 개선했습니다. 이제 충돌하는 세션의 ID를 포함하여 반환하므로 사용자가 상황을 더 명확히 파악할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->